### PR TITLE
Fixing CMake mistakes ++

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@
  *.exe
  *.out
  *.app
+
+
+.vagrant

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,13 @@
 cmake_minimum_required (VERSION 2.8)
 
-set(ROOT_DIR /software/root/root-6.04.00/cmake)
-set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} /software/root/root-6.04.00/cmake/modules)
+set(PROJECT_BASE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+
+set(ROOT_DIR $ENV{ROOTSYS}/cmake)
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} $ENV{ROOTSYS}/cmake/modules)
 
 project (SensorAnalysisToolKit)
 
 set( CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin )
 set( CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib )
 
-add_subdirectory ($ENV{HOME}/SensorAnalysisToolKit/modules)
+add_subdirectory (${PROJECT_BASE_DIR}/modules)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# Preliminary instructions
+
+
+```bash
+git clone https://github.com/BristolImageAnalysis/SensorAnalysisToolkit.git
+cd SensorAnalysisToolkit
+vagrant up
+vagrant ssh
+source /cvmfs/sft.cern.ch/lcg/views/LCG_88/x86_64-slc6-gcc49-opt/setup.sh
+cd /vagrant
+mkdir build
+cd build
+cmake ../
+make -j2
+
+```

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,45 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+# For documentation see https://www.vagrantup.com/docs/vagrantfile/
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  # All Vagrant configuration is done here. The most common configuration
+  # options are documented and commented below. For a complete reference,
+  # please see the online documentation at vagrantup.com.
+
+  # use the CERN VM as a starting point (Scientific Linux 6)
+  config.vm.box = 'cernvm/3-prod'
+
+  # forward ports
+  # config.vm.network :forwarded_port, guest: 8060, host: 8060
+
+  # x-window forwarding (unix-only)
+  config.ssh.forward_x11 = true
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  config.vm.synced_folder ".", "/vagrant", nfs: false
+
+  # if you have an existing vagrant box after this was added in, please run `vagrant provision`
+  # after `vagrant up`.
+  # add your git config to the vagrant box
+  #config.vm.provision "file", source: "~/.gitconfig", destination: "/home/vagrant/.gitconfig"
+
+  # example of executing commands when provisioning the machine
+  config.vm.provision "shell", inline: <<-SHELL
+        sudo mkdir /software
+        sudo chown vagrant /software
+  SHELL
+
+  config.vm.provider "virtualbox" do |vb|
+    # Display the VirtualBox GUI when booting the machine
+    vb.gui = false
+    vb.memory = "2048"
+    vb.cpus = 2
+  end
+end

--- a/modules/CMakeLists.txt
+++ b/modules/CMakeLists.txt
@@ -2,25 +2,22 @@
 
 #cmake_minimum_required (VERSION 2.8)
 
-#set(ROOT_DIR /panfs/panasas01/phys/phrfp/Software/root-6.0.4/cmake)
-#set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} /panfs/panasas01/phys/phrfp/Software/root-6.0.4/cmake/modules)
-
 #project (SensorAnalysisToolKit)
 
 #set( CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin )
 #set( CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib )
 
-add_subdirectory ($ENV{HOME}/SensorAnalysisToolKit/modules/IO/RawIO)
-add_subdirectory ($ENV{HOME}/SensorAnalysisToolKit/modules/IO/RawIOImageStack)
+add_subdirectory (${PROJECT_BASE_DIR}/modules/IO/RawIO)
+add_subdirectory (${PROJECT_BASE_DIR}/modules/IO/RawIOImageStack)
 
-add_subdirectory ($ENV{HOME}/SensorAnalysisToolKit/modules/Base/Image)
-add_subdirectory ($ENV{HOME}/SensorAnalysisToolKit/modules/Base/ImageStack)
+add_subdirectory (${PROJECT_BASE_DIR}/modules/Base/Image)
+add_subdirectory (${PROJECT_BASE_DIR}/modules/Base/ImageStack)
 
-add_subdirectory ($ENV{HOME}/SensorAnalysisToolKit/modules/ImageCalculations/ImageSum)
-add_subdirectory ($ENV{HOME}/SensorAnalysisToolKit/modules/ImageCalculations/ImageDivision)
+add_subdirectory (${PROJECT_BASE_DIR}/modules/ImageCalculations/ImageSum)
+add_subdirectory (${PROJECT_BASE_DIR}/modules/ImageCalculations/ImageDivision)
 
-add_subdirectory ($ENV{HOME}/SensorAnalysisToolKit/modules/ImageCalculations/ImageSubtraction)
-add_subdirectory ($ENV{HOME}/SensorAnalysisToolKit/modules/ImageCalculations/ImageSquare)
-add_subdirectory ($ENV{HOME}/SensorAnalysisToolKit/modules/ImageCalculations/ImageVariance)
+add_subdirectory (${PROJECT_BASE_DIR}/modules/ImageCalculations/ImageSubtract)
+add_subdirectory (${PROJECT_BASE_DIR}/modules/ImageCalculations/ImageSquare)
+add_subdirectory (${PROJECT_BASE_DIR}/modules/ImageCalculations/ImageVariance)
 
-add_subdirectory ($ENV{HOME}/SensorAnalysisToolKit/modules/Plotting/Histograms)
+add_subdirectory (${PROJECT_BASE_DIR}/modules/Plotting/Histograms)

--- a/modules/ImageCalculations/ImageBadPixelAverage/test/CMakeLists.txt
+++ b/modules/ImageCalculations/ImageBadPixelAverage/test/CMakeLists.txt
@@ -52,7 +52,6 @@ target_link_libraries(${PROJECT_TEST_NAME} ${GTEST_LIBS_DIR}/libgtest.a ${GTEST_
 
 target_link_libraries(${PROJECT_TEST_NAME} ${CMAKE_THREAD_LIBS_INIT})
 
-target_link_libraries(${PROJECT_TEST_NAME} ${STK_LIB_DIR}/libstkImageStack.dylib ${STK_LIB_DIR}/libstkImage.dylib ${STK_LIB_DIR}/libstkImageBadPixelAverage.dylib)
+target_link_libraries(${PROJECT_TEST_NAME} stkImageStack stkImage stkImageBadPixelAverage)
 
 add_test(test1 ${PROJECT_TEST_NAME})
-

--- a/modules/ImageCalculations/ImageDivision/test/CMakeLists.txt
+++ b/modules/ImageCalculations/ImageDivision/test/CMakeLists.txt
@@ -52,7 +52,6 @@ target_link_libraries(${PROJECT_TEST_NAME} ${GTEST_LIBS_DIR}/libgtest.a ${GTEST_
 
 target_link_libraries(${PROJECT_TEST_NAME} ${CMAKE_THREAD_LIBS_INIT})
 
-target_link_libraries(${PROJECT_TEST_NAME} ${STK_LIB_DIR}/libstkImageStack.dylib ${STK_LIB_DIR}/libstkImage.dylib ${STK_LIB_DIR}/libstkImageDivision.dylib)
+target_link_libraries(${PROJECT_TEST_NAME} stkImageStack stkImage stkImageDivision)
 
 add_test(test1 ${PROJECT_TEST_NAME})
-

--- a/modules/ImageCalculations/ImageMask/test/CMakeLists.txt
+++ b/modules/ImageCalculations/ImageMask/test/CMakeLists.txt
@@ -52,7 +52,6 @@ target_link_libraries(${PROJECT_TEST_NAME} ${GTEST_LIBS_DIR}/libgtest.a ${GTEST_
 
 target_link_libraries(${PROJECT_TEST_NAME} ${CMAKE_THREAD_LIBS_INIT})
 
-target_link_libraries(${PROJECT_TEST_NAME} ${STK_LIB_DIR}/libstkImageStack.dylib ${STK_LIB_DIR}/libstkImage.dylib ${STK_LIB_DIR}/libstkImageMask.dylib)
+target_link_libraries(${PROJECT_TEST_NAME} stkImageStack stkImage stkImageMask)
 
 add_test(test1 ${PROJECT_TEST_NAME})
-

--- a/modules/ImageCalculations/ImageMinus/test/CMakeLists.txt
+++ b/modules/ImageCalculations/ImageMinus/test/CMakeLists.txt
@@ -52,7 +52,6 @@ target_link_libraries(${PROJECT_TEST_NAME} ${GTEST_LIBS_DIR}/libgtest.a ${GTEST_
 
 target_link_libraries(${PROJECT_TEST_NAME} ${CMAKE_THREAD_LIBS_INIT})
 
-target_link_libraries(${PROJECT_TEST_NAME} ${STK_LIB_DIR}/libstkImageStack.dylib ${STK_LIB_DIR}/libstkImage.dylib ${STK_LIB_DIR}/libstkImageMinus.dylib)
+target_link_libraries(${PROJECT_TEST_NAME} stkImageStack stkImage stkImageMinus)
 
 add_test(test1 ${PROJECT_TEST_NAME})
-

--- a/modules/ImageCalculations/ImageResize/test/CMakeLists.txt
+++ b/modules/ImageCalculations/ImageResize/test/CMakeLists.txt
@@ -52,7 +52,6 @@ target_link_libraries(${PROJECT_TEST_NAME} ${GTEST_LIBS_DIR}/libgtest.a ${GTEST_
 
 target_link_libraries(${PROJECT_TEST_NAME} ${CMAKE_THREAD_LIBS_INIT})
 
-target_link_libraries(${PROJECT_TEST_NAME} ${STK_LIB_DIR}/libstkImageStack.dylib ${STK_LIB_DIR}/libstkImage.dylib ${STK_LIB_DIR}/libstkImageResize.dylib)
+target_link_libraries(${PROJECT_TEST_NAME} stkImageStack stkImage stkImageResize)
 
 add_test(test1 ${PROJECT_TEST_NAME})
-

--- a/modules/ImageCalculations/ImageSquare/test/CMakeLists.txt
+++ b/modules/ImageCalculations/ImageSquare/test/CMakeLists.txt
@@ -52,7 +52,6 @@ target_link_libraries(${PROJECT_TEST_NAME} ${GTEST_LIBS_DIR}/libgtest.a ${GTEST_
 
 target_link_libraries(${PROJECT_TEST_NAME} ${CMAKE_THREAD_LIBS_INIT})
 
-target_link_libraries(${PROJECT_TEST_NAME} ${STK_LIB_DIR}/libstkImageStack.dylib ${STK_LIB_DIR}/libstkImage.dylib ${STK_LIB_DIR}/libstkImageSquare.dylib)
+target_link_libraries(${PROJECT_TEST_NAME} stkImageStack stkImage stkImageSquare)
 
 add_test(test1 ${PROJECT_TEST_NAME})
-

--- a/modules/ImageCalculations/ImageSubtract/test/CMakeLists.txt
+++ b/modules/ImageCalculations/ImageSubtract/test/CMakeLists.txt
@@ -52,7 +52,6 @@ target_link_libraries(${PROJECT_TEST_NAME} ${GTEST_LIBS_DIR}/libgtest.a ${GTEST_
 
 target_link_libraries(${PROJECT_TEST_NAME} ${CMAKE_THREAD_LIBS_INIT})
 
-target_link_libraries(${PROJECT_TEST_NAME} ${STK_LIB_DIR}/libstkImageStack.dylib ${STK_LIB_DIR}/libstkImage.dylib ${STK_LIB_DIR}/libstkImageSubtract.dylib)
+target_link_libraries(${PROJECT_TEST_NAME} stkImageStack stkImage stkImageSubtract)
 
 add_test(test1 ${PROJECT_TEST_NAME})
-

--- a/modules/ImageCalculations/ImageSum/test/CMakeLists.txt
+++ b/modules/ImageCalculations/ImageSum/test/CMakeLists.txt
@@ -52,7 +52,6 @@ target_link_libraries(${PROJECT_TEST_NAME} ${GTEST_LIBS_DIR}/libgtest.a ${GTEST_
 
 target_link_libraries(${PROJECT_TEST_NAME} ${CMAKE_THREAD_LIBS_INIT})
 
-target_link_libraries(${PROJECT_TEST_NAME} ${STK_LIB_DIR}/libstkImageStack.dylib ${STK_LIB_DIR}/libstkImage.dylib ${STK_LIB_DIR}/libstkImageSum.dylib)
+target_link_libraries(${PROJECT_TEST_NAME} stkImageStack stkImage stkImageSum)
 
 add_test(test1 ${PROJECT_TEST_NAME})
-

--- a/modules/ImageCalculations/ImageVariance/test/CMakeLists.txt
+++ b/modules/ImageCalculations/ImageVariance/test/CMakeLists.txt
@@ -52,7 +52,6 @@ target_link_libraries(${PROJECT_TEST_NAME} ${GTEST_LIBS_DIR}/libgtest.a ${GTEST_
 
 target_link_libraries(${PROJECT_TEST_NAME} ${CMAKE_THREAD_LIBS_INIT})
 
-target_link_libraries(${PROJECT_TEST_NAME} ${STK_LIB_DIR}/libstkImageStack.dylib ${STK_LIB_DIR}/libstkImage.dylib ${STK_LIB_DIR}/libstkImageVariance.dylib)
+target_link_libraries(${PROJECT_TEST_NAME} stkImageStack stkImage stkImageVariance)
 
 add_test(test1 ${PROJECT_TEST_NAME})
-

--- a/modules/Plotting/Histograms/CMakeLists.txt
+++ b/modules/Plotting/Histograms/CMakeLists.txt
@@ -8,19 +8,17 @@ set(SOURCE_FILES include/stkImageHistogram.hxx)
 set(INCLUDE_FILES include/stkImageHistogram.h )
 message( STATUS "Source files: ${SOURCE_FILES}" )
 
-set(PROJECT_RAW_IO_SOURCE $ENV{HOME}/SensorAnalysisToolKit)
+set(PROJECT_RAW_IO_SOURCE EXT_PROJECTS_DIR)
 set(TEST_LIB_DIR ${PROJECT_RAW_IO_SOURCE}/build/lib/)
 
-set(EXT_PROJECTS_DIR $ENV{HOME}/Software)
-set(ROOT_INCLUDE_DIRS ${EXT_PROJECTS_DIR}/root-6.0.4/include)
-set(ROOT_LIB_DIR ${EXT_PROJECTS_DIR}/root-6.0.4/lib )
+# set(EXT_PROJECTS_DIR $ENV{HOME}/Software)
+set(ROOT_INCLUDE_DIRS $ENV{ROOTSYS}/include)
+set(ROOT_LIB_DIR $ENV{ROOTSYS}/lib )
 include_directories(${ROOT_INCLUDE_DIRS})
 
 #Add library
 add_library( stkImageHistogram SHARED ${SOURCE_FILES} ${INCLUDE_FILES} )
 
-target_link_libraries(stkImageHistogram ${TEST_LIB_DIR}/libstkRawIO.dylib ${TEST_LIB_DIR}/libstkImage.dylib )
+target_link_libraries(stkImageHistogram stkRawIO stkImage )
 
 set_target_properties(stkImageHistogram PROPERTIES LINKER_LANGUAGE CXX)
-
-

--- a/modules/Plotting/Histograms/test/CMakeLists.txt
+++ b/modules/Plotting/Histograms/test/CMakeLists.txt
@@ -2,8 +2,8 @@
 
 cmake_minimum_required(VERSION 2.8.8)
 
-set(ROOT_DIR /panfs/panasas01/phys/phrfp/Software/root-6.0.4/cmake)
-set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} /panfs/panasas01/phys/phrfp/Software/root-6.0.4/cmake/modules)
+set(ROOT_DIR $ENV{ROOTSYS}/cmake)
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} $ENV{ROOTSYS}/cmake/modules)
 
 set(PROJECT_NAME_STR ImageHist)
 project(${PROJECT_NAME_STR})
@@ -19,7 +19,7 @@ endif()
 #-------------------
 # set common include folder for module
 #-------------------
-set(PROJECT_RAW_IO_SOURCE $ENV{HOME}/SensorAnalysisToolKit)
+set(PROJECT_RAW_IO_SOURCE ${PROJECT_BASE_DIR})
 set(COMMON_INCLUDES ${PROJECT_RAW_IO_SOURCE}/modules/IO/RawIO/include ${PROJECT_RAW_IO_SOURCE}/modules/Base/Image/include ${PROJECT_RAW_IO_SOURCE}/modules/Plotting/Histograms/include )
 message(STATUS "Common includes ${COMMON_INCLUDES}")
 set(EXT_PROJECTS_DIR $ENV{HOME}/Software)
@@ -53,4 +53,3 @@ target_link_libraries( ${PROJECT_TEST_NAME} ${ROOT_LIBRARIES})
 target_link_libraries(${PROJECT_TEST_NAME} ${TEST_LIB_DIR}/libstkRawIO.so ${TEST_LIB_DIR}/libstkImage.so ${TEST_LIB_DIR}/libstkImageHistogram.so )
 
 add_test(test1 ${PROJECT_TEST_NAME})
-


### PR DESCRIPTION
 - added README and Vagrantfile
 - replaced `ROOT_DIR` with `ROOTSYS`
 - removed hardcoded library suffix (using cmake targets instead)